### PR TITLE
Fix Build with new package versions and remove js error on landing

### DIFF
--- a/client/app/js/app.jsx
+++ b/client/app/js/app.jsx
@@ -40,7 +40,9 @@ class App extends React.Component {
 
   componentDidMount = () => {
     BoardStore.addChangeListener(this._onChange);
-    BoardActions.fetchAll();
+    if(!this.props.landing) {
+      BoardActions.fetchAll();
+    }
   }
 
   setFilterHandler = () => {

--- a/client/app/js/board.jsx
+++ b/client/app/js/board.jsx
@@ -5,7 +5,7 @@ import Ajax from 'basic-ajax';
 import StoryShowDialog from './story_show_dialog';
 import BoardStore from './store/BoardStore';
 
-class Board extends React.Component {
+export default class Board extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -77,5 +77,3 @@ class Board extends React.Component {
     </div>
   }
 }
-
-export default Board;

--- a/client/app/js/board_canvas.js
+++ b/client/app/js/board_canvas.js
@@ -6,7 +6,7 @@ import TaskCanvas from './task_canvas';
 import BoardActions from './actions/BoardActions';
 import BoardStore from './store/BoardStore';
 
-class BoardCanvas {
+export default class BoardCanvas {
   constructor(container, handler) {
     let scale_factor = (window.innerWidth - 20)/window.screen.availWidth;
     let card_sorter = function(a, b) {
@@ -90,4 +90,3 @@ class BoardCanvas {
     this.layer.draw();
   }
 }
-export default BoardCanvas;

--- a/client/app/js/board_dialog.jsx
+++ b/client/app/js/board_dialog.jsx
@@ -59,4 +59,3 @@ export default class BoardDialog extends React.Component {
     );
   }
 }
-export default BoardDialog;

--- a/client/app/js/board_layout.jsx
+++ b/client/app/js/board_layout.jsx
@@ -12,7 +12,7 @@ import TaskDialog from './task_dialog';
 import Colors from './color';
 import BoardStore from './store/BoardStore';
 
-class BoardLayout extends Layout  {
+export default class BoardLayout extends Layout  {
   constructor(props) {
     super(props);
     this.state = this.getDialogState();
@@ -77,5 +77,3 @@ class BoardLayout extends Layout  {
      </div>
   }
 }
-
-export default BoardLayout;

--- a/client/app/js/card_canvas.js
+++ b/client/app/js/card_canvas.js
@@ -85,7 +85,7 @@ class CardGroup extends Konva.Group {
   }
 }
 
-class CardCanvas {
+export default class CardCanvas {
   constructor(card, stage, layout, type) {
     this.card = card;
     this.stage = stage;
@@ -97,4 +97,3 @@ class CardCanvas {
     layout.call(this);
   }
 }
-export default CardCanvas;

--- a/client/app/js/column_canvas.js
+++ b/client/app/js/column_canvas.js
@@ -14,7 +14,7 @@ class ColumnGroup extends Konva.Group {
   }
 }
 
-class ColumnCanvas {
+export default class ColumnCanvas {
   constructor(width, height, column) {
     this.KonvaElement = new ColumnGroup(width, height, column);
     var column_background = new Konva.Rect({
@@ -44,4 +44,3 @@ class ColumnCanvas {
     this.KonvaElement.add(text);
   }
 }
-export default ColumnCanvas;

--- a/client/app/js/column_dialog.jsx
+++ b/client/app/js/column_dialog.jsx
@@ -57,4 +57,3 @@ export default class ColumnDialog extends React.Component {
     );
   }
 }
-export default ColumnDialog;

--- a/client/app/js/story_edit_dialog.jsx
+++ b/client/app/js/story_edit_dialog.jsx
@@ -122,4 +122,3 @@ export default class StoryEditDialog extends React.Component {
     return this.editForm();
   }
 }
-export default StoryEditDialog;

--- a/client/app/js/story_point_picker.jsx
+++ b/client/app/js/story_point_picker.jsx
@@ -53,4 +53,3 @@ export default class StoryPointPicker extends React.Component {
     </div>
   }
 }
-export default StoryPointPicker;

--- a/client/app/js/story_select.jsx
+++ b/client/app/js/story_select.jsx
@@ -33,5 +33,3 @@ export default class StorySelect extends React.Component {
     </SelectField>
   }
 }
-
-export default StorySelect;

--- a/client/app/js/story_show_dialog.jsx
+++ b/client/app/js/story_show_dialog.jsx
@@ -84,4 +84,3 @@ export default class StoryShowDialog extends React.Component {
     return this.showForm();
   }
 }
-export default StoryShowDialog;

--- a/client/app/js/task_dialog.jsx
+++ b/client/app/js/task_dialog.jsx
@@ -112,4 +112,3 @@ export default class TaskDialog extends React.Component {
     );
   }
 }
-export default TaskDialog;

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
     "react-markdown": "^2.4.2",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "git+https://github.com/zilverline/react-tap-event-plugin.git#master",
     "simple-ajax": "^2.5.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
- After updating the node modules we got an error with the
  "react-tap-event-plugin". A fix was found at:
  https://github.com/thereactivestack/meteor-webpack/issues/21
  We have to have an eye on that issue I guess
- Got an js error on the landing page. fetchAll was always called
  but should only be called when not on the landing page