### PR TITLE
Clear Task Edit Fields for new Cards and new Stories

### DIFF
--- a/client/app/js/store/BoardStore.js
+++ b/client/app/js/store/BoardStore.js
@@ -481,6 +481,7 @@ var updateTask = (data) => {
       if (response_obj.success) {
         resolve(data);
         task_dialog_open = false;
+        selected_story_id = null;
       } else {
         var obj_errors = response_obj.messages;
         var error_fields = ErrorFields.TASK;

--- a/client/app/js/story_edit_dialog.jsx
+++ b/client/app/js/story_edit_dialog.jsx
@@ -23,7 +23,8 @@ const default_form_values = {
 export default class StoryEditDialog extends React.Component {
   constructor(props) {
     super(props);
-    this.state = this.getState(default_form_values);
+    var new_form_values = JSON.parse(JSON.stringify(default_form_values));
+    this.state = this.getState(new_form_values);
   }
 
   getState = (form_values) => {
@@ -53,13 +54,19 @@ export default class StoryEditDialog extends React.Component {
     var story = BoardStore.getStory();
     if (story && story !== this.state.story) {
       this.setState(this.getState(story));
-    } else if (!story && this.state.story) {
-      this.setDefaultFormValues();
+    }
+  }
+
+  componentWillUpdate = (nextProps) => {
+    if (!this.props.open && nextProps.open) {
+      var new_form_values = JSON.parse(JSON.stringify(default_form_values));
+      this.setState(this.getState(new_form_values));
     }
   }
 
   setDefaultFormValues = () => {
-    this.setState({story: null, form_values: default_form_values, });
+    var new_form_values = JSON.parse(JSON.stringify(default_form_values));
+    this.setState({story: null, form_values: new_form_values});
   }
 
   handleFormSubmit = () => {

--- a/client/app/js/task_dialog.jsx
+++ b/client/app/js/task_dialog.jsx
@@ -20,7 +20,8 @@ const default_form_values = {
 export default class TaskDialog extends React.Component {
   constructor(props) {
     super(props);
-    this.state = this.getState(default_form_values);
+    var new_form_values = JSON.parse(JSON.stringify(default_form_values));
+    this.state = this.getState(new_form_values);
   }
 
   getState = (form_values) => {
@@ -36,6 +37,7 @@ export default class TaskDialog extends React.Component {
       new_state.last_sel_story_id = new_state.task.story_id;
     } else if (form_values) {
       new_state.form_values = form_values;
+      new_state.last_sel_story_id = null;
     }
 
     return new_state;
@@ -77,8 +79,16 @@ export default class TaskDialog extends React.Component {
     BoardStore.addChangeListener(this._onChange);
   }
 
+  componentWillUpdate = (nextProps) => {
+    if (!this.props.open && nextProps.open) {
+      var new_form_values = JSON.parse(JSON.stringify(default_form_values));
+      this.setState(this.getState(new_form_values));
+    }
+  }
+
   setDefaultFormValues = () => {
-    this.setState({form_values: default_form_values});
+    var new_form_values = JSON.parse(JSON.stringify(default_form_values));
+    this.setState({form_values: new_form_values});
   }
 
   handleFormSubmit = () => {


### PR DESCRIPTION
1. We cannot to rely on the contructor to clear the
   form fields for us, since our task dialog will only
   be contructed once and lives until page reload.
2. We need to "dup" the default_form_values const,
   otherwise the reference is used and the changes
   will be made on the default_form_values which
   also live until next page reload.

This closes #202 