### PR TITLE
Menu Drop Down closes with websoket event

### DIFF
--- a/client/__tests__/Sidebar.react-test.jsx
+++ b/client/__tests__/Sidebar.react-test.jsx
@@ -30,7 +30,7 @@ describe('<Sidebar />', () => {
       <Sidebar />
     );
     expect(wrapper.state().selected_stories).toEqual([]);
-    BoardActions.showTasksForStoryId(1);
+    BoardActions.toggleTasksForStoryId(1);
     expect(wrapper.state().selected_stories).toEqual([1]);
   });
 });

--- a/client/app/js/actions/BoardActions.js
+++ b/client/app/js/actions/BoardActions.js
@@ -120,6 +120,11 @@ var BoardActions = {
       story_id: story_id
     });
   },
+  toggleBoardMenu: () =>  {
+    AppDispatcher.dispatch({
+      actionType: "TOGGLE_MENU"
+    });
+  },
   closeStoryShowDialog: () =>  {
     AppDispatcher.dispatch({
       actionType: "CLOSE_STORY_SHOW_DIALOG",

--- a/client/app/js/board_layout.jsx
+++ b/client/app/js/board_layout.jsx
@@ -13,6 +13,7 @@ import StoryFromIssueEditDialog from './story_from_issue_edit_dialog';
 import TaskDialog from './task_dialog';
 import Colors from './color';
 import BoardStore from './store/BoardStore';
+import BoardActions from './actions/BoardActions';
 
 export default class BoardLayout extends Layout  {
   constructor(props) {
@@ -43,12 +44,14 @@ export default class BoardLayout extends Layout  {
 
   handleTouchTapMenuBtn = (event) => {
     event.preventDefault();
-    this.setState({menu_open: true, menu_achor: event.currentTarget});
+    BoardActions.toggleBoardMenu();
+    this.setState({menu_achor: event.currentTarget});
   }
 
   handleTouchTapCloseMenu = () => {
     var achor_element = this.state.menu_achor;
-    this.setState({menu_open: false, menu_achor: achor_element});
+    BoardActions.toggleBoardMenu();
+    this.setState({menu_achor: achor_element});
   }
 
   render() {

--- a/client/app/js/store/BoardStore.js
+++ b/client/app/js/store/BoardStore.js
@@ -772,6 +772,14 @@ AppDispatcher.register(function(action) {
         BoardStore.emitChange();
       }
       break;
+    case "TOGGLE_MENU":
+      if (menu_open) {
+        menu_open = false;
+      } else {
+        menu_open = true;
+      }
+      BoardStore.emitChange();
+      break;
     case "SHOW_CHART_DIALOG":
       chart_dialog_open = true;
       fetchBurnDownData().then(() => {BoardStore.emitChange();});


### PR DESCRIPTION
If we received a websocket event, we reset the
menu_open to the value which was stored in the BoardStore
which was always false.

We fix that by updating the board store instead of updating
the board_layout state.

closes #207