### PR TITLE
Replace github dependency with official npm source

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
     "react-chartjs": "^0.8.0",
     "react-dom": "^15.2.1",
     "react-markdown": "^2.4.2",
-    "react-tap-event-plugin": "git+https://github.com/zilverline/react-tap-event-plugin.git#master",
+    "react-tap-event-plugin": "2.0.1",
     "simple-ajax": "^2.5.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
- Why is the change necessary?
npm install and gulp fails due to a missing dependency.

- How does the change address the issue?
Pull react-tap-event-plugin from npm instead of github.