### PR TITLE
set story on task create

### DIFF
--- a/client/app/js/actions/BoardActions.js
+++ b/client/app/js/actions/BoardActions.js
@@ -88,10 +88,11 @@ var BoardActions = {
       actionType: "CLOSE_CONFIRMATION"
     });
   },
-  showTaskDialog: (task_id) =>  {
+  showTaskDialog: (task_id, story_id) =>  {
     AppDispatcher.dispatch({
       actionType: "SHOW_TASK_DIALOG",
-      task_id: task_id
+      task_id: task_id,
+      story_id: story_id,
     });
   },
   showChartDialog: () =>  {

--- a/client/app/js/store/BoardStore.js
+++ b/client/app/js/store/BoardStore.js
@@ -782,6 +782,7 @@ AppDispatcher.register(function(action) {
       task_dialog_open = true;
       task_show_dialog_open = false;
       task_edit_id = action.task_id;
+      selected_story_id = action.story_id;
       BoardStore.emitChange();
       break;
     case "CLOSE_TASK_DIALOG":

--- a/client/app/js/story_card.jsx
+++ b/client/app/js/story_card.jsx
@@ -31,7 +31,7 @@ export default class StoryCard extends React.Component {
 
   onClickAddTaskHandler = (event) => {
     event.stopPropagation();
-    BoardActions.showTaskDialog();
+    BoardActions.showTaskDialog(null, this.props.story_id);
   }
 
   // This is needed for testing the a component without the whole app context

--- a/client/app/js/task_dialog.jsx
+++ b/client/app/js/task_dialog.jsx
@@ -25,10 +25,11 @@ export default class TaskDialog extends React.Component {
   }
 
   getState = (form_values) => {
+    var story_id = BoardStore.getSelectedStoryId();
     var new_state = {
       error: ErrorStore.getTaskErrors(),
       task: BoardStore.getTask(),
-      last_sel_story_id: BoardStore.getSelectedStoryId(),
+      last_sel_story_id: story_id,
       users: BoardStore.getUsersForBoard()
     };
 
@@ -37,7 +38,7 @@ export default class TaskDialog extends React.Component {
       new_state.last_sel_story_id = new_state.task.story_id;
     } else if (form_values) {
       new_state.form_values = form_values;
-      new_state.last_sel_story_id = null;
+      new_state.last_sel_story_id = story_id;
     }
 
     return new_state;


### PR DESCRIPTION
If we click the "+" icon (Task create) near the story,
the story should be preselected on the task dialog view.